### PR TITLE
chore: coc.nvim のインストール方法を最新化する

### DIFF
--- a/vim/dein.toml
+++ b/vim/dein.toml
@@ -53,8 +53,8 @@ endif
 
 [[plugins]]
 repo = 'neoclide/coc.nvim'
-if = '''executable('node') && executable('yarn')'''
-build = './install.sh nightly'
+if = '''executable('node')'''
+rev = 'release'
 merged = '0'
 hook_add = '''
 nmap <Leader>c [coc.nvim]


### PR DESCRIPTION
- https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim#using-deinvim