### PR TITLE
refactor: dein.vim の toml ファイルへカラースキーム設定を全て移す

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -15,10 +15,6 @@ augroup highlightIdegraphicSpace
   autocmd VimEnter,WinEnter * match IdeographicSpace /　/
 augroup END
 
-" カラースキーム -------------------------
-set background=dark
-colorscheme iceberg
-
 " 設定 -------------------------
 " カレントバッファのファイルの文字エンコーディング
 set fileencodings=utf-8,sjis

--- a/vim/dein.toml
+++ b/vim/dein.toml
@@ -7,6 +7,13 @@ on_ft = 'toml'
 
 [[plugins]]
 repo = 'cocopon/iceberg.vim'
+hook_add = '''
+  set background=dark
+  augroup colorschemeSetting
+    autocmd!
+    autocmd VimEnter * ++nested colorscheme iceberg
+  augroup END
+'''
 
 [[plugins]]
 repo = 'junegunn/fzf'


### PR DESCRIPTION
## 参考
- [dein.vimによるプラグイン管理のマイベストプラクティス - Qiita](https://qiita.com/kawaz/items/ee725f6214f91337b42b)
- [autocmd - Vim日本語ドキュメント](https://vim-jp.org/vimdoc-ja/autocmd.html)