### PR TITLE
fix: vim 起動時に coc.nvim のエラーが発生したのでインストール方法を修正することで解消する

### DIFF
--- a/vim/dein.toml
+++ b/vim/dein.toml
@@ -61,7 +61,6 @@ endif
 [[plugins]]
 repo = 'neoclide/coc.nvim'
 if = '''executable('node')'''
-rev = 'release'
 merged = '0'
 hook_add = '''
 nmap <Leader>c [coc.nvim]


### PR DESCRIPTION
```
/Users/oki2a24/.cache/dein/repos/github.com/neoclide/coc.nvim_release/plugin/coc.vim の処理中にエラーが検出されました:
行  484: E1208: -complete used without -nargs続けるにはENTERを押すかコマンドを入力してください
```

https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim#using-deinvim